### PR TITLE
bugfix: add presence check for childResourceType

### DIFF
--- a/packages/app/components/resource/ResourceInstanceValueFormInput.vue
+++ b/packages/app/components/resource/ResourceInstanceValueFormInput.vue
@@ -328,7 +328,7 @@ function setAllTo(value: any) {
         </template>
 
         <ResourceInstanceValueNestedForm
-          v-else
+          v-else-if="childResourceType"
           :model-value="modelValue"
           :field="field"
           :resource-type="resourceType"


### PR DESCRIPTION
This PR resolves an issue where sometimes navigating within the GUI causes a blocking error with .fields being undefined.

## How to run locally ?

In the project where moquerie is being used update the npm script as follows to point towards your fork

```
    "start-moquerie": "node /home/user/Projects/github.com/project-name/moquerie/packages/moquerie/bin.mjs",
```